### PR TITLE
Feature Exercise Info 158626056

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -33,12 +33,13 @@ class ExerciseInfoSerializer(serializers.ModelSerializer):
     '''
     Exercise Info serializer
     '''
+    image = serializers.StringRelatedField(source='get_this_image', many=True)
 
     class Meta:
         model = Exercise
         fields = ('category', 'creation_date', 'description', 'language',
                   'muscles', 'muscles_secondary', 'status', 'name',
-                  'equipment', 'license', 'license_author')
+                  'equipment', 'license', 'license_author', 'image')
 
 
 class EquipmentSerializer(serializers.ModelSerializer):

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -29,6 +29,18 @@ class ExerciseSerializer(serializers.ModelSerializer):
         model = Exercise
 
 
+class ExerciseInfoSerializer(serializers.ModelSerializer):
+    '''
+    Exercise Info serializer
+    '''
+
+    class Meta:
+        model = Exercise
+        fields = ('category', 'creation_date', 'description', 'language',
+                  'muscles', 'muscles_secondary', 'status', 'name',
+                  'equipment', 'license', 'license_author')
+
+
 class EquipmentSerializer(serializers.ModelSerializer):
     '''
     Equipment serializer

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 
+from django.utils.encoding import force_text
 from rest_framework import serializers
 from wger.exercises.models import (Muscle, Exercise, ExerciseImage,
                                    ExerciseCategory, Equipment,
@@ -33,13 +34,17 @@ class ExerciseInfoSerializer(serializers.ModelSerializer):
     '''
     Exercise Info serializer
     '''
-    image = serializers.StringRelatedField(source='get_this_image', many=True)
+    image = serializers.StringRelatedField(source='main_image', read_only=True)
 
     class Meta:
         model = Exercise
         fields = ('category', 'creation_date', 'description', 'language',
                   'muscles', 'muscles_secondary', 'status', 'name',
                   'equipment', 'license', 'license_author', 'image')
+        depth = 1
+
+    def get_image(self, obj):
+        return force_text(obj.main_image)
 
 
 class EquipmentSerializer(serializers.ModelSerializer):

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -28,7 +28,8 @@ from django.utils.translation import ugettext as _
 from wger.config.models import LanguageConfig
 from wger.exercises.api.serializers import (
     MuscleSerializer, ExerciseSerializer, ExerciseImageSerializer,
-    ExerciseCategorySerializer, EquipmentSerializer, ExerciseCommentSerializer)
+    ExerciseCategorySerializer, EquipmentSerializer, ExerciseCommentSerializer,
+    ExerciseInfoSerializer)
 from wger.exercises.models import (Exercise, Equipment, ExerciseCategory,
                                    ExerciseImage, ExerciseComment, Muscle)
 from wger.utils.language import load_item_languages, load_language
@@ -102,6 +103,15 @@ def search(request):
         json_response['suggestions'] = results
 
     return Response(json_response)
+
+
+class ExerciseInfoViewSet(viewsets.ReadOnlyModelViewSet):
+    '''
+    API endpoint for exercise info
+    '''
+    queryset = Exercise.objects.all()
+    serializer_class = ExerciseInfoSerializer
+    ordering_fields = '__all__'
 
 
 class EquipmentViewSet(viewsets.ReadOnlyModelViewSet):

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -293,6 +293,14 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
         return self.exerciseimage_set.accepted().filter(is_main=True).first()
 
     @property
+    def get_this_image(self):
+        # obj = self.exerciseimage_set.all()
+        # if obj:
+        #     data = serializers.serialize('json', obj)
+        #     return json.loads(data)[0]["fields"]["image"]
+        return self.exerciseimage_set.all()
+
+    @property
     def description_clean(self):
         '''
         Return the exercise description with all markup removed
@@ -395,6 +403,9 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel,
         Set default ordering
         '''
         ordering = ['-is_main', 'id']
+
+    def __str__(self):
+        return '%s' % (self.image)
 
     def save(self, *args, **kwargs):
         '''

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -293,14 +293,6 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
         return self.exerciseimage_set.accepted().filter(is_main=True).first()
 
     @property
-    def get_this_image(self):
-        # obj = self.exerciseimage_set.all()
-        # if obj:
-        #     data = serializers.serialize('json', obj)
-        #     return json.loads(data)[0]["fields"]["image"]
-        return self.exerciseimage_set.all()
-
-    @property
     def description_clean(self):
         '''
         Return the exercise description with all markup removed
@@ -403,9 +395,6 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel,
         Set default ordering
         '''
         ordering = ['-is_main', 'id']
-
-    def __str__(self):
-        return '%s' % (self.image)
 
     def save(self, *args, **kwargs):
         '''

--- a/wger/exercises/tests/test_exercise_info.py
+++ b/wger/exercises/tests/test_exercise_info.py
@@ -1,0 +1,33 @@
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+
+
+class ExerciseInfoTestCase(WorkoutManagerTestCase):
+    '''
+    Test Exercise Info Endpoint
+    '''
+
+    def test_exercise_info(self):
+        '''
+        Test endpoint returns exercise infomation
+        '''
+        endpoint = "/api/v2/exerciseInfo/"
+
+        res = self.client.get(endpoint)
+
+        self.assertEqual(res.status_code, 200)
+
+        self.assertIn("license_author", str(res.data))
+
+        self.assertIn("license", str(res.data))
+
+        self.assertIn("category", str(res.data))
+
+        self.assertIn("language", str(res.data))
+
+        self.assertIn("muscles", str(res.data))
+
+        self.assertIn("muscles_secondary", str(res.data))
+
+        self.assertIn("equipment", str(res.data))
+
+        self.assertIn("image", str(res.data))

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -123,6 +123,8 @@ router.register(
 router.register(
     r'exercise', exercises_api_views.ExerciseViewSet, base_name='exercise')
 router.register(
+    r'exerciseInfo', exercises_api_views.ExerciseInfoViewSet, base_name='exerciseInfo')
+router.register(
     r'equipment', exercises_api_views.EquipmentViewSet, base_name='api')
 router.register(
     r'exercisecategory',


### PR DESCRIPTION
**What does this PR do?**
Creates a read-only API endpoint that collects all the information of an exercise.

**Description of Task to be completed?**
Add a read only API endpoint to retrieve exercise information such as muscles, category, images if it exists, etc.

**How should this be manually tested?**
Clone repo and run server locally
Use Postman or Curl to send a GET request to `http://localhost:8000/api/v2/exerciseInfo/`
The endpoint should only accept GET requests

**Any background context you want to provide?**
This task uses django-rest-framework

**What are the relevant pivotal tracker stories?**
[#158626056](https://www.pivotaltracker.com/story/show/158626056)

**Screenshot**
<img width="769" alt="screen shot 2018-07-11 at 12 48 36" src="https://user-images.githubusercontent.com/24602451/42567710-476ce9a8-8513-11e8-9225-09f8cc9404f7.png">
