### PR TITLE
[Ft #158626063] allow comparison of members data

### DIFF
--- a/wger/gym/static/js/comparison_chart.js
+++ b/wger/gym/static/js/comparison_chart.js
@@ -1,0 +1,82 @@
+let user_plot_data = JSON.parse(user_data.replace(/&quot;/g,'"'));
+console.log(user_plot_data);
+let user_weights = user_plot_data[0];
+let dates = user_plot_data[1];
+let plot_data = [];
+
+function getRandomColor() {
+  let letters = '0123456789ABCDEF';
+  let color = '#';
+  for (let i = 0; i < 6; i++) {
+    color += letters[Math.floor(Math.random() * 16)];
+  }
+  return color;
+}
+
+Chart.defaults.line.spanGaps = true;
+
+for (let user in user_weights) {
+  color = getRandomColor();
+  if (user_weights.hasOwnProperty(user)) {
+    plot_data.push({
+      label: user,
+      data: user_weights[user],
+      lineTension: 0.3,
+      fill: false,
+      backgroundColor: color,
+      borderColor: color,
+    })
+  }
+}
+
+let chartData = {
+  labels: dates,
+  datasets: plot_data,
+};
+
+let chartOptions = {
+  legend: {
+    display: true,
+    spanGaps: true,
+    position: 'top',
+    labels: {
+      boxWidth: 80,
+      fontColor: 'black'
+    }
+  },
+  title: {
+    text: 'Gym member weight comparison'
+  },
+  scales: {
+    yAxes: [{
+      scaleLabel: {
+        display: true,
+        labelString: 'Weight in Kg',
+      }
+    }],
+    xAxes: [{
+      scaleLabel: {
+        display: true,
+        labelString: 'Date',
+      }
+    }]
+  },
+};
+
+window.onload = function () {
+  let ctx = document.getElementById("chart");
+  new Chart(ctx, {
+  type: 'line',
+  data: chartData,
+  options: chartOptions
+});
+};
+
+
+
+
+
+
+
+
+

--- a/wger/gym/static/js/comparison_chart.js
+++ b/wger/gym/static/js/comparison_chart.js
@@ -37,9 +37,9 @@ let chartOptions = {
   legend: {
     display: true,
     spanGaps: true,
-    position: 'top',
+    position: 'right',
     labels: {
-      boxWidth: 80,
+      boxWidth: 15,
       fontColor: 'black'
     }
   },
@@ -51,7 +51,7 @@ let chartOptions = {
       scaleLabel: {
         display: true,
         labelString: 'Weight in Kg',
-      }
+      },
     }],
     xAxes: [{
       scaleLabel: {

--- a/wger/gym/static/js/comparison_chart.js
+++ b/wger/gym/static/js/comparison_chart.js
@@ -1,5 +1,4 @@
 let user_plot_data = JSON.parse(user_data.replace(/&quot;/g,'"'));
-console.log(user_plot_data);
 let user_weights = user_plot_data[0];
 let dates = user_plot_data[1];
 let plot_data = [];
@@ -69,14 +68,5 @@ window.onload = function () {
   type: 'line',
   data: chartData,
   options: chartOptions
-});
+  });
 };
-
-
-
-
-
-
-
-
-

--- a/wger/gym/templates/gym/chart.html
+++ b/wger/gym/templates/gym/chart.html
@@ -1,0 +1,8 @@
+{% load i18n staticfiles %}
+
+<script>
+    var user_data = "{{ user_plot_data }}";
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.js"></script>
+<script type="text/javascript" src="{% static 'js/comparison_chart.js' %}" ></script>
+<canvas id="chart" width="600" height="400"></canvas>

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -89,6 +89,9 @@
 {% endfor %}
 </tbody>
 </table>
+
+<h4>Member Weight Comparison</h4>
+    {% include 'gym/chart.html' %}
 {% endblock %}
 
 


### PR DESCRIPTION
**What does this PR do?**
Adds a line chart to the gym administration page that shows the comparison between different users' weight data over time. This data is available to trainers and gym admins only.

**Description of task to be completed**
When two users are training together it would be useful to see a comparison of some sorts.

**How should this be manually tested**
- Log in as admin
- Navigate to the gym page
- Add users and for each user add some weight entries
- The users weight comparison should appear on the chart

**Relevant pivotal tracker stories**
[#158626063](https://www.pivotaltracker.com/story/show/158626063)

**Screenshots**
*Comparison of the members in the gym*
<img width="811" alt="screen shot 2018-07-18 at 17 12 36" src="https://user-images.githubusercontent.com/25581395/42887181-03ad3a56-8aae-11e8-88e0-b0dc770db3b9.png">

*Focus on a particular member*
<img width="786" alt="screen shot 2018-07-18 at 17 13 02" src="https://user-images.githubusercontent.com/25581395/42887240-26d7b9a2-8aae-11e8-90be-06410fb2c76a.png">



