### PR TITLE
#158626074 Get exercises on body part tabs hover

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -18,7 +18,7 @@ $(document).ready(function() {
 
     // Init the autocompleter
     $('#exercise-search').autocomplete({
-        serviceUrl: '{% url 'exercise-search' %}',
+        serviceUrl: "{% url 'exercise-search' %}",
         showNoSuggestionNotice: true,
         dataType: 'json',
         paramName: 'term',
@@ -48,7 +48,7 @@ $(document).ready(function() {
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}
-    <li {% if forloop.first %}class="active"{% endif %}>
+    <li  class="{% if forloop.first %} active {% endif %}" >
         <a href="#tab-{{ item.grouper.id }}" id="category-{{ item.grouper.id }}" data-toggle="tab" class="body-part-tab">{% trans item.grouper.name %}</a>
     </li>
     {% empty %}

--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -28,6 +28,12 @@ $(document).ready(function() {
             window.location.href = '/exercise/' + suggestion.data.id + '/view/'
         }
     });
+
+    // show specific body parts on hovering
+    $('ul').find('a').hover(function() {
+        $(this).tab('show');
+    });
+
 });
 </script>
 {% endblock %}
@@ -43,7 +49,7 @@ $(document).ready(function() {
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}
     <li {% if forloop.first %}class="active"{% endif %}>
-        <a href="#tab-{{ item.grouper.id }}" id="category-{{ item.grouper.id }}" data-toggle="tab">{% trans item.grouper.name %}</a>
+        <a href="#tab-{{ item.grouper.id }}" id="category-{{ item.grouper.id }}" data-toggle="tab" class="body-part-tab">{% trans item.grouper.name %}</a>
     </li>
     {% empty %}
         <li>{% trans "No categories." %} {% trans "Use link to create one" %}</li>


### PR DESCRIPTION
**What does this PR do?**
Assign hover event to body part tabs.

**Description of Task to be completed?**
The user should be able to move my mouse over a body part and get exercises for that body part.

**How should this be manually tested?**
- Clone the repo, ```cd``` into the wg-leo directory and run ```./manage.py runserver```. 
- Navigate to the URL provided by the development server (usually ```localhost```) using a browser.
- Create an account or log in
- Navigate to ```Exercises``` dropdown menu at the Navigation bar.
- Click ```Exercises``` link.
- Hover mouse on body parts to view the body part exercises

**What are the relevant pivotal tracker stories?**
[#158626074](https://www.pivotaltracker.com/story/show/158626074)

**Screenshots**
![2gpnsriziy](https://user-images.githubusercontent.com/24792513/43102437-d54d88f8-8ed3-11e8-843a-5c2443f7908c.gif)
